### PR TITLE
Sponsored infinite grid: mobile fullscreen fallback

### DIFF
--- a/components/sponsored-by-me/SponsoredAppsInfiniteGrid.vue
+++ b/components/sponsored-by-me/SponsoredAppsInfiniteGrid.vue
@@ -7,14 +7,62 @@ import type {
 } from "~/components/ui/infinite-grid/types";
 import { useSettings } from "~/composables/settings";
 import { sponsoredApps } from "~/constants/sponsored-apps";
-import { useFullscreen } from "@vueuse/core";
+import { onKeyStroke, useFullscreen } from "@vueuse/core";
 import { Maximize2, Minimize2 } from "lucide-vue-next";
 
 const { t } = useI18n();
 const { reducedMotion } = useSettings();
 
 const fullscreenRef = ref<HTMLElement | null>(null);
-const { isFullscreen, toggle } = useFullscreen(fullscreenRef);
+const { isFullscreen, isSupported, enter, exit } = useFullscreen(fullscreenRef);
+
+/**
+ * iOS / many mobile browsers do not expose Fullscreen API for generic elements,
+ * so `useFullscreen` is unsupported and native `toggle()` does nothing.
+ * This mirrors fullscreen visually with fixed positioning + scroll lock.
+ */
+const pseudoFullscreen = ref(false);
+
+const inFullscreen = computed(
+  () => isFullscreen.value || pseudoFullscreen.value,
+);
+
+function setBodyScrollLocked(locked: boolean) {
+  if (!import.meta.client) {
+    return;
+  }
+  document.body.style.overflow = locked ? "hidden" : "";
+}
+
+async function toggleFullscreen() {
+  if (isFullscreen.value) {
+    await exit();
+    return;
+  }
+  if (pseudoFullscreen.value) {
+    pseudoFullscreen.value = false;
+    setBodyScrollLocked(false);
+    return;
+  }
+  if (isSupported.value) {
+    try {
+      await enter();
+      return;
+    } catch {
+      /* fall through to pseudo */
+    }
+  }
+  pseudoFullscreen.value = true;
+  setBodyScrollLocked(true);
+}
+
+onKeyStroke("Escape", () => {
+  if (!pseudoFullscreen.value) {
+    return;
+  }
+  pseudoFullscreen.value = false;
+  setBodyScrollLocked(false);
+});
 
 /** Signals `Cursor.vue` to hide the custom cursor while the grid is in browser fullscreen. */
 const sponsoredInfiniteGridFullscreen = useState(
@@ -23,14 +71,19 @@ const sponsoredInfiniteGridFullscreen = useState(
 );
 
 watch(
-  isFullscreen,
+  inFullscreen,
   (v) => {
     sponsoredInfiniteGridFullscreen.value = v;
   },
   { immediate: true },
 );
 
-onBeforeUnmount(() => {
+onBeforeUnmount(async () => {
+  if (isFullscreen.value) {
+    await exit();
+  }
+  pseudoFullscreen.value = false;
+  setBodyScrollLocked(false);
   sponsoredInfiniteGridFullscreen.value = false;
 });
 
@@ -96,8 +149,10 @@ function onTileClicked(detail: TileClickEventDetail) {
       ref="fullscreenRef"
       :class="[
         'relative overflow-hidden rounded-2xl border border-neutral-800/80 bg-neutral-950 shadow-[0_24px_80px_-24px_rgba(0,0,0,0.55)] ring-1 ring-white/10 light:border-neutral-200 light:bg-neutral-950 light:ring-black/10',
-        isFullscreen
-          ? 'h-screen max-h-[100dvh] w-screen max-w-none rounded-none'
+        inFullscreen
+          ? pseudoFullscreen
+            ? 'fixed inset-0 z-[9998] h-[100dvh] max-h-[100dvh] w-screen max-w-none rounded-none'
+            : 'h-screen max-h-[100dvh] w-screen max-w-none rounded-none'
           : 'w-full max-w-6xl',
       ]"
     >
@@ -105,20 +160,20 @@ function onTileClicked(detail: TileClickEventDetail) {
         type="button"
         class="absolute right-3 top-3 z-20 flex h-10 w-10 items-center justify-center rounded-lg border border-white/15 bg-black/55 text-white shadow-lg backdrop-blur-md transition hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950 light:border-white/25 light:bg-white/90 light:text-neutral-900 light:hover:bg-white light:focus-visible:ring-neutral-400 light:focus-visible:ring-offset-white md:right-4 md:top-4"
         :aria-label="
-          isFullscreen
+          inFullscreen
             ? t('sponsoredByMe.exitFullscreen')
             : t('sponsoredByMe.enterFullscreen')
         "
-        :aria-pressed="isFullscreen"
-        @click="toggle()"
+        :aria-pressed="inFullscreen"
+        @click="toggleFullscreen()"
       >
-        <Minimize2 v-if="isFullscreen" class="h-5 w-5" aria-hidden="true" />
+        <Minimize2 v-if="inFullscreen" class="h-5 w-5" aria-hidden="true" />
         <Maximize2 v-else class="h-5 w-5" aria-hidden="true" />
       </button>
       <div
         :class="[
           'w-full',
-          isFullscreen ? 'h-full min-h-0' : 'h-[min(70vh,560px)] md:h-[min(70vh,640px)]',
+          inFullscreen ? 'h-full min-h-0' : 'h-[min(70vh,560px)] md:h-[min(70vh,640px)]',
         ]"
       >
         <InfiniteGrid


### PR DESCRIPTION
Adds a fixed-position pseudo-fullscreen when the browser Fullscreen API is unavailable (typical on mobile Safari), with body scroll lock and Escape to exit. Follow-up to the merged sponsored-by-me infinite grid work.

Made with [Cursor](https://cursor.com)